### PR TITLE
fix(h2): content-length missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"bytes"
 
 	"golang.org/x/net/http2"
 )
@@ -26,8 +27,12 @@ func makeH2Request(
 		Timeout:   time.Duration(timeout) * time.Second,
 		Transport: tr,
 	}
-
-	req, err := http.NewRequest(method, url, requestBody)
+	b, err := io.ReadAll(requestBody)
+	if err != nil {
+		return err
+	}
+	reqBody := bytes.NewBuffer(b)
+	req, err := http.NewRequest(method, url, reqBody)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func makeH2Request(
 		Timeout:   time.Duration(timeout) * time.Second,
 		Transport: tr,
 	}
+        // convert the buffer to a interface that supports `.Len()` so that Content-Length header is added
 	b, err := io.ReadAll(requestBody)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary

This commit changes the code so that it always adds the content-length header to requests.

Someone more familiar with this project should take a look.