### PR TITLE
fix: check stdin reader lenght in main function cause panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,15 +150,7 @@ func main() {
 	var body io.Reader
 	if *postFlag {
 		method = "POST"
-		stdin := os.Stdin
-		fi, err := stdin.Stat()
-		if err != nil {
-			panic(err)
-		}
-		size := fi.Size()
-		if size > 0 {
-			body = stdin
-		}
+		body = os.Stdin
 	} else {
 		method = "GET"
 	}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 func makeH2Request(
 	method string, url string,
 	headerMap map[string]string, requestBody io.Reader,
-	timeout int, tr http.RoundTripper) error {
+	timeout int, tr http.RoundTripper, stremMode bool) error {
 
 	// Create client with timeout and transport
 	client := http.Client{
@@ -30,7 +30,7 @@ func makeH2Request(
 
 	var reqBody *bytes.Buffer
 
-	if requestBody == nil {
+	if requestBody == nil || stremMode {
 		reqBody = new(bytes.Buffer)
 	} else {
 		// convert the buffer to a interface that supports `.Len()` so that Content-Length header is added
@@ -119,6 +119,7 @@ func main() {
 	headersFlag := flag.String("headers", "", "Headers to set, comma separated")
 	http1Flag := flag.Bool("http1", false, "Use HTTP/1.[01] protocol")
 	postFlag := flag.Bool("post", false, "Use POST, body is read from standard input")
+	streamMode := flag.Bool("stream", false, "Use stream mode in HTTP2 transport, which means the request has no 'Content-Length' header")
 	flag.Parse()
 
 	// Create headers map
@@ -156,7 +157,7 @@ func main() {
 	}
 
 	// Make request
-	err := makeH2Request(method, *url, headerMap, body, *timeout, tr)
+	err := makeH2Request(method, *url, headerMap, body, *timeout, tr, *streamMode)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
before this change:
```
╰─$ bin/busted -o gtest ./plugins-ee/forward-proxy/spec/05-access-large-payload_spec.lua                                                                                                                                                    130 ↵
[==========] Running tests from scanned files.
[----------] Global test environment setup.
[----------] Running tests from ./plugins-ee/forward-proxy/spec/05-access-large-payload_spec.lua
[ RUN      ] ...s-ee/forward-proxy/spec/05-access-large-payload_spec.lua:255: proxy non-streaming proxy HTTP/2
HTTP/2 reason:
failed to write to stdin: closed
./spec/helpers.lua:1245: Nil error
[  ERROR   ] ...s-ee/forward-proxy/spec/05-access-large-payload_spec.lua:255: proxy non-streaming proxy HTTP/2 (32.41 ms)
[----------] 1 test from ./plugins-ee/forward-proxy/spec/05-access-large-payload_spec.lua (2969.80 ms total)

[----------] Global test environment teardown.
[==========] 1 test from 1 test file ran. (2970.18 ms total)
[  PASSED  ] 0 tests.
[  ERROR   ] 1 error, listed below:
[  ERROR   ] ...s-ee/forward-proxy/spec/05-access-large-payload_spec.lua:255: proxy non-streaming proxy HTTP/2

 1 ERROR
```

After this change
```
╰─$ cp ../h2client/h2client ./bin                                                                                                                                                                                                             1 ↵
(kong-dev) ╭─ouyang@owl-home ~/work/kong/self/kong-ee ‹cherry-pick/chrono-0c5fe199d-2024-01-19●› 
╰─$ bin/busted -o gtest ./plugins-ee/forward-proxy/spec/05-access-large-payload_spec.lua
[==========] Running tests from scanned files.
[----------] Global test environment setup.
[----------] Running tests from ./plugins-ee/forward-proxy/spec/05-access-large-payload_spec.lua
[ RUN      ] ...s-ee/forward-proxy/spec/05-access-large-payload_spec.lua:255: proxy non-streaming proxy HTTP/2
HTTP/2 reason:
exit
[       OK ] ...s-ee/forward-proxy/spec/05-access-large-payload_spec.lua:255: proxy non-streaming proxy HTTP/2 (168.87 ms)
[----------] 1 test from ./plugins-ee/forward-proxy/spec/05-access-large-payload_spec.lua (3007.33 ms total)

[----------] Global test environment teardown.
[==========] 1 test from 1 test file ran. (3007.61 ms total)
[  PASSED  ] 1 test.
```